### PR TITLE
[ACCMOB] Disable crash collector

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarInfrastructure.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarInfrastructure.m
@@ -46,9 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
 
     [[RollbarTelemetry sharedInstance] configureWithOptions:config.telemetry];
 
-    self.collector = [[RollbarCrashCollector alloc] init];
-    [self.collector install];
-    [self.collector sendAllReports];
+/* Wise has tooling already in place for crash reports, so we don't want to handle crashes in Rollbar. Currently there's no option to disable this from the public API of the Rollbar SDK. */
+
+//    self.collector = [[RollbarCrashCollector alloc] init];
+//    [self.collector install];
+//    [self.collector sendAllReports];
 
     // Create RollbarThread and begin processing persisted occurrences
     if ([[RollbarThread sharedInstance] active]) {


### PR DESCRIPTION
## Description of the change

Based on the indication provided by the RollBar team [here](https://wise-ext.slack.com/archives/C02STD0PDR9/p1715791029685309?thread_ts=1713188933.868639&cid=C02STD0PDR9), this PR should allow to stop us tracking crashes
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
