### PR TITLE
Xcode 16 support

### DIFF
--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
@@ -40,7 +40,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <typeinfo>
-
+#include <stdexcept>
 
 #define STACKTRACE_BUFFER_LENGTH 30
 #define DESCRIPTION_BUFFER_LENGTH 1000
@@ -49,7 +49,6 @@
 // Compiler hints for "if" statements
 #define likely_if(x) if(__builtin_expect(x,1))
 #define unlikely_if(x) if(__builtin_expect(x,0))
-
 
 // ============================================================================
 #pragma mark - Globals -

--- a/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
+++ b/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
@@ -37,7 +37,7 @@ struct Timestamp: RawRepresentable {
 
 extension Timestamp: Equatable, Comparable, Hashable, Codable {}
 
-private final class ISO8601Formatter: DateFormatter {
+private final class ISO8601Formatter: DateFormatter, @unchecked Sendable {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -52,7 +52,7 @@ private final class ISO8601Formatter: DateFormatter {
     }
 }
 
-private final class RFC3339Formatter: DateFormatter {
+private final class RFC3339Formatter: DateFormatter, @unchecked Sendable {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)


### PR DESCRIPTION
## Context
There was a compiler error saying it couldn't find terminate_handler inside the std namespace. Some Googling brought me to this adding this import, which seems to resolve the issue but I've no idea if this is "correct" or not. I've also asked Rollbar if fixing this is on their Radar.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 