### PR TITLE
Xcode 16 compilation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Notes
 
+### 3.3.1
+
+- Fixes a compilation issue present in Xcode 16 beta.
+
 ### 3.3.0
 
 - Added Privacy Manifest to fulfill the new SDK privacy requirements from Apple.

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
@@ -40,7 +40,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <typeinfo>
-#include <stdexcept>
+
 
 #define STACKTRACE_BUFFER_LENGTH 30
 #define DESCRIPTION_BUFFER_LENGTH 1000
@@ -49,6 +49,7 @@
 // Compiler hints for "if" statements
 #define likely_if(x) if(__builtin_expect(x,1))
 #define unlikely_if(x) if(__builtin_expect(x,0))
+
 
 // ============================================================================
 #pragma mark - Globals -

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
@@ -39,17 +39,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <exception>
 #include <typeinfo>
-
 
 #define STACKTRACE_BUFFER_LENGTH 30
 #define DESCRIPTION_BUFFER_LENGTH 1000
 
-
 // Compiler hints for "if" statements
 #define likely_if(x) if(__builtin_expect(x,1))
 #define unlikely_if(x) if(__builtin_expect(x,0))
-
 
 // ============================================================================
 #pragma mark - Globals -

--- a/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
+++ b/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
@@ -37,7 +37,7 @@ struct Timestamp: RawRepresentable {
 
 extension Timestamp: Equatable, Comparable, Hashable, Codable {}
 
-private final class ISO8601Formatter: DateFormatter, @unchecked Sendable {
+private final class ISO8601Formatter: DateFormatter {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -52,7 +52,7 @@ private final class ISO8601Formatter: DateFormatter, @unchecked Sendable {
     }
 }
 
-private final class RFC3339Formatter: DateFormatter, @unchecked Sendable {
+private final class RFC3339Formatter: DateFormatter {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)

--- a/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
+++ b/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
@@ -37,7 +37,7 @@ struct Timestamp: RawRepresentable {
 
 extension Timestamp: Equatable, Comparable, Hashable, Codable {}
 
-private final class ISO8601Formatter: DateFormatter {
+private final class ISO8601Formatter: DateFormatter, @unchecked Sendable {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -52,7 +52,7 @@ private final class ISO8601Formatter: DateFormatter {
     }
 }
 
-private final class RFC3339Formatter: DateFormatter {
+private final class RFC3339Formatter: DateFormatter, @unchecked Sendable {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)


### PR DESCRIPTION
## Context
Reverts commits to support Xcode 16 and patch solution from original Rollbar repo we forked from


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 